### PR TITLE
Corrected the package manager spelling 'ban' to 'bun' in code-dialog.tsx

### DIFF
--- a/app/(site)/[slug]/components/code-dialog.tsx
+++ b/app/(site)/[slug]/components/code-dialog.tsx
@@ -33,7 +33,7 @@ export default async function CodeDialog({ example }: Props) {
       code: `npx shadcn@latest add ${process.env.BASE_URL}/r/${example.href}.json`
     },
     {
-      name: "ban",
+      name: "bun",
       code: `bunx --bun shadcn@latest add ${process.env.BASE_URL}/r/${example.href}.json`
     }
   ];


### PR DESCRIPTION
**Corrected the package manager spelling 'ban' to 'bun' in code-dialog.tsx**

<img width="886" height="604" alt="image" src="https://github.com/user-attachments/assets/8927955b-ef05-4d85-a70b-8392f53a379b" />
