### PR TITLE
✨feat: add copy to clipboard functionality in code preview

### DIFF
--- a/app/(site)/[slug]/components/tab-code-preview.tsx
+++ b/app/(site)/[slug]/components/tab-code-preview.tsx
@@ -12,7 +12,7 @@ export default function TabCodePreview() {
     <div className="relative w-full overflow-auto">
       <CodeBlock code={code} lang="tsx" />
       <div className="absolute end-2 top-2">
-        <CopyToClipboard text={code as string} />
+        <CopyToClipboard text={code || ""} />
       </div>
     </div>
   );

--- a/app/(site)/[slug]/components/tab-code-preview.tsx
+++ b/app/(site)/[slug]/components/tab-code-preview.tsx
@@ -3,9 +3,17 @@
 import React from "react";
 import { useCodeCopyStore } from "@/store/use-copy-code";
 import CodeBlock from "@/components/code-renderer";
+import CopyToClipboard from "@/components/copy-to-clipboard";
 
 export default function TabCodePreview() {
   const { code } = useCodeCopyStore();
 
-  return <CodeBlock code={code} lang="tsx" />;
+  return (
+    <div className="relative w-full overflow-auto">
+      <CodeBlock code={code} lang="tsx" />
+      <div className="absolute end-2 top-2">
+        <CopyToClipboard text={code as string} />
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
This PR introduces a **copy-to-clipboard** button for the code preview component, allowing users to easily copy code snippets with a single click.

<img width="886" height="646" alt="image" src="https://github.com/user-attachments/assets/d1f8d5b9-ae51-46b6-b603-8e93db6c59f3" />